### PR TITLE
New structure to construct query joins and orderBy

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,21 @@ use LifeOnScreen\SortRelations\SortRelations;
 class Product extends Resource
 {
     public static $sortRelations = [
-        // overriding id with product.id (this prevent ambiguous id, if you select multiple ids)
-        'id'               => 'product.id',
+        // Order product relation by product id...
+        'product'               => 'id',
         // overriding user relation sorting
         'user'         => [
             // sorting multiple columns
-            'users.name',
-            'users.surname',
+            'name',
+            'surname',
         ],
         // overriding company relation sorting
-        'company'          => 'company.name',
+        'company'          => 'name',
     ];
     
     public static function indexQuery(NovaRequest $request, $query)
     {
-        // You can modify your base query here.
+        // You can modify your base query here, only if necessary. Sort Relations will be applied automatically...
         return $query;
     }
 }

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ $ composer require lifeonscreen/nova-sort-relations
 
 ## Usage
 
-Include `LifeOnScreen\SortRelations\SortRelations` trait to your class. Define base by overriding `indexQuery`.
-Define sortable columns in `$sortRelations` array.
+Include `LifeOnScreen\SortRelations\SortRelations` trait to your class. Define sortable columns in `$sortRelations` array.
 
 ```php
 

--- a/src/SortRelations.php
+++ b/src/SortRelations.php
@@ -20,9 +20,9 @@ trait SortRelations
         $model = $query->getModel();
         $return = [];
         if (static::$sortRelations) {
-            foreach (static::$sortRelation as $relation => $columns) {
+            foreach (static::$sortRelations as $relation => $columns) {
                 $relatedKey = $model->{$relation}()->getForeignKeyName();
-                $return[$relatedkey] = ['relation' => $relation, 'columns' => $columns];
+                $return[$relatedKey] = ['relation' => $relation, 'columns' => $columns];
             }
         }
         return $return;

--- a/src/SortRelations.php
+++ b/src/SortRelations.php
@@ -71,6 +71,8 @@ trait SortRelations
         $sortRelations = static::sortableRelations();
 
         foreach ($orderings as $column => $direction) {
+            if (is_null($direction))
+              $direction = 'asc';
             if (array_key_exists($column, $sortRelations)) {
                 $query = self::applyRelationOrderings($column, $direction, $query);
             } else {

--- a/src/SortRelations.php
+++ b/src/SortRelations.php
@@ -44,17 +44,19 @@ trait SortRelations
         $relation = $sortRelations[$column];
         $related = $model->{$relation['relation']}()->getRelated();
 
-        $foreignKey = Str::snake($relation['relation']) . '_' . $related->getKeyName();
+        $foreignKey =  $model->{$relation['relation']}()->getForeignKeyName();
+        $ownerKey = $model->{$relation['relation']}()->getOwnerKeyName();
 
         $query->select($model->getTable() . '.*');
-        $query->leftJoin($related->getTable(), $model->qualifyColumn($foreignKey), '=', $related->qualifyColumn($related->getKeyName()));
+        $query->leftJoin($related->getTable(), $model->qualifyColumn($foreignKey), '=', $related->qualifyColumn($ownerKey));
         if (is_string($relation['columns'])) {
             $qualified = $related->qualifyColumn($relation['columns']);
             $query->orderBy($qualified, $direction);
         }
         if (is_array($relation['columns'])) {
             foreach ($relation['columns'] as $orderColumn) {
-                $query->orderBy($related->qualifyColumn($orderColumn), $direction);
+                $qualified = $related->qualifyColumn($orderColumn);
+                $query->orderBy($qualified, $direction);
             }
         }
 

--- a/src/SortRelations.php
+++ b/src/SortRelations.php
@@ -48,7 +48,7 @@ trait SortRelations
         $ownerKey = $model->{$relation['relation']}()->getOwnerKeyName();
 
         $query->select($model->getTable() . '.*');
-        $query->leftJoin($related->getTable(), $model->qualifyColumn($foreignKey), '=', $related->qualifyColumn($ownerKey));
+        $query->leftJoin($related->getConnection()->getDatabaseName() . '.' . $related->getTable(), $model->qualifyColumn($foreignKey), '=', $related->qualifyColumn($ownerKey));
         if (is_string($relation['columns'])) {
             $qualified = $related->qualifyColumn($relation['columns']);
             $query->orderBy($qualified, $direction);

--- a/src/SortRelations.php
+++ b/src/SortRelations.php
@@ -2,6 +2,8 @@
 
 namespace LifeOnScreen\SortRelations;
 
+use Illuminate\Support\Str;
+
 /**
  * Trait SortRelations
  * @package LifeOnScreen\SortRelations
@@ -37,7 +39,7 @@ trait SortRelations
         $foreignKey = Str::snake($relation) . '_' . $related->getKeyName();
 
         $query->select($model->getTable() . '.*');
-        $query->join($related->getTable(), $model->qualifyColumn($foreignKey), '=', $related->qualifyColumn($related->getKeyName()));
+        $query->leftJoin($related->getTable(), $model->qualifyColumn($foreignKey), '=', $related->qualifyColumn($related->getKeyName()));
         if (is_string($sortRelations[$column])) {
             $qualified = $related->qualifyColumn($sortRelations[$column]);
             $query->orderBy($qualified, $direction);


### PR DESCRIPTION
Hi @janicerar,

This is my contribution for your package to create a simple way to configure $sortRelations, using always a structure of [ '<relation>' => '<relation-column>] or ['<relation>' => ['<relation-column-1','<relation-column-2>', ... '<relation-column-n>]. I've merged my solutions for some problems with @anderly solutions to create a unique and more embracing solution.

Thank's for your great package and for the opportunity of my contribution.